### PR TITLE
Implement rate limiting for authentication and signup endpoints

### DIFF
--- a/config.env.js
+++ b/config.env.js
@@ -69,6 +69,20 @@ module.exports = {
     signup: {
       enabled: !/^false$/i.test(process.env.MEILING_SIGNUP_ENABLED || ''),
     },
+    rateLimit: {
+      authentication: {
+        max: Number(process.env.MEILING_RATE_LIMIT_AUTHENTICATION_MAX) || 30,
+        timeframe: Number(process.env.MEILING_RATE_LIMIT_AUTHENTICATION_TIME_FRAME) || 600,
+      },
+      recovery: {
+        max: Number(process.env.MEILING_RATE_LIMIT_RECOVERY_MAX) || 10,
+        timeframe: Number(process.env.MEILING_RATE_LIMIT_RECOVERY_TIME_FRAME) || 3600,
+      },
+      signup: {
+        max: Number(process.env.MEILING_RATE_LIMIT_SIGNUP_MAX) || 10,
+        timeframe: Number(process.env.MEILING_RATE_LIMIT_SIGNUP_TIME_FRAME) || 3600,
+      },
+    },
   },
   session: {
     v1: {

--- a/config.example.js
+++ b/config.example.js
@@ -72,6 +72,21 @@ module.exports = {
       /** Enable meiliNG Internal Signup? set it to false to disable (e.g. only use custom signup process) */
       enabled: !/^false$/i.test(process.env.MEILING_SIGNUP_ENABLED || ''),
     },
+    /** Rate limits for security-sensitive user authentication endpoints. */
+    rateLimit: {
+      authentication: {
+        max: 30,
+        timeframe: 600,
+      },
+      recovery: {
+        max: 10,
+        timeframe: 3600,
+      },
+      signup: {
+        max: 10,
+        timeframe: 3600,
+      },
+    },
   },
   session: {
     /** Configures Version 1 of the meiliNG Session */

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@fastify/cors": "^8.2.0",
     "@fastify/formbody": "^7.3.0",
+    "@fastify/rate-limit": "9.1.0",
     "@fastify/swagger": "^8.1.0",
     "@prisma/client": "4.16.2",
     "@sentry/node": "^7.9.0",
@@ -23,6 +24,7 @@
     "fastify": "^4.10.2",
     "fastify-secure-session": "^2.3.0",
     "figlet": "^1.5.0",
+    "ipaddr.js": "2.4.0",
     "jsonwebtoken": "^8.5.1",
     "libphonenumber-js": "^1.9.49",
     "mysql2": "^2.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@fastify/formbody':
         specifier: ^7.3.0
         version: 7.3.0
+      '@fastify/rate-limit':
+        specifier: 9.1.0
+        version: 9.1.0
       '@fastify/swagger':
         specifier: ^8.1.0
         version: 8.1.0(supports-color@5.5.0)
@@ -56,6 +59,9 @@ importers:
       figlet:
         specifier: ^1.5.0
         version: 1.5.2
+      ipaddr.js:
+        specifier: 2.4.0
+        version: 2.4.0
       jsonwebtoken:
         specifier: ^8.5.1
         version: 8.5.1
@@ -388,6 +394,9 @@ packages:
   '@fastify/formbody@7.3.0':
     resolution: {integrity: sha512-4uHTS7wH0mkUoltk4wyJ966rs/TQP0BNDSCtyqRMy7p5adGg+5ERbYue/zGh/qI9yLDPN0K98u7Fw+lLEmBZJQ==}
 
+  '@fastify/rate-limit@9.1.0':
+    resolution: {integrity: sha512-h5dZWCkuZXN0PxwqaFQLxeln8/LNwQwH9popywmDCFdKfgpi4b/HoMH1lluy6P+30CG9yzzpSpwTCIPNB9T1JA==}
+
   '@fastify/swagger@8.1.0':
     resolution: {integrity: sha512-i0keOF4O8x/02vk2QV2raWEB4TdSnEob5IWpOerq2VRyIV0W2jtq2Ujr5bSzmlg3ZiGM/t6rBfkfRTIez7YAXA==}
 
@@ -410,6 +419,10 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@lukeed/ms@2.0.2':
+    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
+    engines: {node: '>=8'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1315,8 +1328,8 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
-  ipaddr.js@2.0.1:
-    resolution: {integrity: sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==}
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
     engines: {node: '>= 10'}
 
   is-arrayish@0.2.1:
@@ -1995,6 +2008,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toad-cache@3.7.4:
+    resolution: {integrity: sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==}
+    engines: {node: '>=20'}
+
   touch@3.1.0:
     resolution: {integrity: sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==}
     hasBin: true
@@ -2259,6 +2276,12 @@ snapshots:
       fast-querystring: 1.0.0
       fastify-plugin: 4.3.0
 
+  '@fastify/rate-limit@9.1.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      fastify-plugin: 4.3.0
+      toad-cache: 3.7.4
+
   '@fastify/swagger@8.1.0(supports-color@5.5.0)':
     dependencies:
       fastify-plugin: 4.3.0
@@ -2284,6 +2307,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@lukeed/ms@2.0.2': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -2313,7 +2338,7 @@ snapshots:
     dependencies:
       '@peculiar/asn1-schema': 2.3.3
       asn1js: 3.0.5
-      ipaddr.js: 2.0.1
+      ipaddr.js: 2.4.0
       pvtsutils: 1.3.2
       tslib: 2.4.1
 
@@ -3278,7 +3303,7 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
-  ipaddr.js@2.0.1: {}
+  ipaddr.js@2.4.0: {}
 
   is-arrayish@0.2.1: {}
 
@@ -3967,6 +3992,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toad-cache@3.7.4: {}
 
   touch@3.1.0:
     dependencies:

--- a/src/common/fastify/index.ts
+++ b/src/common/fastify/index.ts
@@ -4,6 +4,8 @@ import { nameStylized } from '..';
 import { info as packageJson } from '../../resources/package';
 import config from '../../resources/config';
 
+export { normalizeRateLimitIP, rateLimitCacheSize, rateLimitDefaults } from './rate-limit';
+
 // TODO: Typescript sucks. fix later.
 export function setupSwaggerUI(app: any) {
   app.register(fastifySwagger, {

--- a/src/common/fastify/rate-limit.ts
+++ b/src/common/fastify/rate-limit.ts
@@ -1,0 +1,20 @@
+import ipaddr from 'ipaddr.js';
+
+export const rateLimitCacheSize = 2_500;
+export const rateLimitDefaults = {
+  authentication: { max: 30, timeframe: 600 },
+  recovery: { max: 10, timeframe: 3600 },
+  signup: { max: 10, timeframe: 3600 },
+};
+
+export function normalizeRateLimitIP(ip: string): string {
+  const address = ipaddr.process(ip);
+
+  if (address.kind() === 'ipv6') {
+    const bytes = address.toByteArray();
+    bytes.fill(0, 8);
+    return ipaddr.fromByteArray(bytes).toString();
+  }
+
+  return address.toString();
+}

--- a/src/common/meiling/v1/session.ts
+++ b/src/common/meiling/v1/session.ts
@@ -30,8 +30,6 @@ let tokenSessions: MeilingV1TokenDataFile = {
   issuedTokens: [],
 };
 
-const lastIssueRequest: Record<string, Date> = {};
-
 export function loadSessionSaveFiles(): void {
   if (config.session.v1.storage) {
     if (config.session.v1.storage.type === 'file') {
@@ -139,29 +137,11 @@ export function getTokenFromRequest(req: FastifyRequest): string | undefined {
   return token ? token.token : undefined;
 }
 
-export async function createToken(req: FastifyRequest): Promise<string | undefined> {
-  // TODO: make this more configurable
-  if (lastIssueRequest[req.ip] !== undefined) {
-    const date = lastIssueRequest[req.ip];
-    const rateLimitWindow = 100;
-
-    if (date.getTime() + rateLimitWindow > new Date().getTime()) {
-      throw new Meiling.V1.Error.MeilingError(Meiling.V1.Error.ErrorType.RATE_LIMITED);
-    }
-  }
-
+export async function createToken(req: FastifyRequest): Promise<string> {
   const token = Meiling.Authentication.Token.generateToken();
   const expiration = new Date(new Date().getTime() + config.session.v1.maxAge * 1000);
-  const userTimeFieldMinimum = new Date().getTime() - config.session.v1.rateLimit.timeframe * 1000;
 
   if (config.session.v1.storage) {
-    if (
-      tokenSessions.issuedTokens.filter((t) => t.ip === req.ip && userTimeFieldMinimum < t.issuedAt.getTime()).length >
-      config.session.v1.rateLimit.maxTokenPerIP
-    ) {
-      return undefined;
-    }
-
     const tokenData: MeilingV1TokenData = {
       token,
       ip: req.ip,
@@ -173,19 +153,6 @@ export async function createToken(req: FastifyRequest): Promise<string | undefin
 
     tokenSessions.issuedTokens.push(tokenData);
   } else {
-    const userSessions = await getPrismaClient().meilingSessionV1Token.findMany({
-      where: {
-        ip: req.ip,
-        issuedAt: {
-          gt: new Date(userTimeFieldMinimum),
-        },
-      },
-    });
-
-    if (userSessions.length > config.session.v1.rateLimit.maxTokenPerIP) {
-      return undefined;
-    }
-
     await getPrismaClient().meilingSessionV1Token.create({
       data: {
         token,
@@ -199,7 +166,6 @@ export async function createToken(req: FastifyRequest): Promise<string | undefin
   }
 
   saveSession();
-  lastIssueRequest[req.ip] = new Date();
 
   return token;
 }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -74,6 +74,11 @@ export interface ConfigInterface {
     signup: {
       enabled: boolean;
     };
+    rateLimit?: {
+      authentication?: RateLimitConfig;
+      recovery?: RateLimitConfig;
+      signup?: RateLimitConfig;
+    };
   };
   session: {
     v1: {
@@ -131,4 +136,9 @@ export interface ConfigInterface {
       url: string[];
     };
   };
+}
+
+interface RateLimitConfig {
+  max: number;
+  timeframe: number;
 }

--- a/src/routes/v1/meiling/authentication/index.ts
+++ b/src/routes/v1/meiling/authentication/index.ts
@@ -1,10 +1,19 @@
-import { FastifyInstance, FastifyPluginOptions } from 'fastify';
+import { FastifyInstance, FastifyPluginOptions, preHandlerAsyncHookHandler } from 'fastify';
 import { meilingV1SessionAuthnIssueHandler } from './issue';
 import { meilingV1SessionAuthnVerifyHandler } from './verify';
 
-export function meilingV1SessionAuthnPlugin(app: FastifyInstance, opts: FastifyPluginOptions, done: () => void): void {
-  app.post('/issue', meilingV1SessionAuthnIssueHandler);
-  app.post('/verify', meilingV1SessionAuthnVerifyHandler);
+interface MeilingV1SessionAuthnPluginOptions extends FastifyPluginOptions {
+  authenticationRateLimit: preHandlerAsyncHookHandler;
+  recoveryRateLimit: preHandlerAsyncHookHandler;
+}
+
+export function meilingV1SessionAuthnPlugin(
+  app: FastifyInstance,
+  opts: MeilingV1SessionAuthnPluginOptions,
+  done: () => void,
+): void {
+  app.post('/issue', { preHandler: opts.recoveryRateLimit }, meilingV1SessionAuthnIssueHandler);
+  app.post('/verify', { preHandler: opts.authenticationRateLimit }, meilingV1SessionAuthnVerifyHandler);
 
   done();
 }

--- a/src/routes/v1/meiling/index.ts
+++ b/src/routes/v1/meiling/index.ts
@@ -1,3 +1,4 @@
+import fastifyRateLimit from '@fastify/rate-limit';
 import { FastifyInstance, FastifyPluginOptions, FastifyRequest } from 'fastify';
 import fastifyCors from '@fastify/cors';
 import { NodeEnvironment } from '../../../interface';
@@ -13,6 +14,7 @@ import { signupPlugin } from './signup/';
 import { userPlugin } from './users';
 import { sentryErrorHandler } from '../../../common/sentry/tracer';
 import { User as UserModel } from '@prisma/client';
+import { normalizeRateLimitIP, rateLimitCacheSize, rateLimitDefaults } from '../../../common/fastify';
 
 export interface FastifyRequestWithSession extends FastifyRequest {
   session: Meiling.V1.Interfaces.MeilingSession;
@@ -23,6 +25,17 @@ export interface FastifyRequestWithUser extends FastifyRequestWithSession {
 }
 
 function meilingV1Plugin(app: FastifyInstance, opts: FastifyPluginOptions, done: () => void): void {
+  app.register(fastifyRateLimit, {
+    global: false,
+    cache: rateLimitCacheSize,
+    keyGenerator: (req) => normalizeRateLimitIP(req.ip),
+    errorResponseBuilder: () =>
+      new Meiling.V1.Error.MeilingError(
+        Meiling.V1.Error.ErrorType.RATE_LIMITED,
+        'Too many requests. Please try again later.',
+      ),
+  });
+
   app.addSchema({
     $id: 'MeilingV1Error',
     description: 'Common error response of meiliNG',
@@ -80,6 +93,19 @@ function meilingV1Plugin(app: FastifyInstance, opts: FastifyPluginOptions, done:
 }
 
 function sessionRequiredPlugin(app: FastifyInstance, opts: FastifyPluginOptions, done: () => void): void {
+  const authenticationConfig = config.meiling.rateLimit?.authentication ?? rateLimitDefaults.authentication;
+  const recoveryConfig = config.meiling.rateLimit?.recovery ?? rateLimitDefaults.recovery;
+  const authenticationRateLimit = app.rateLimit({
+    max: authenticationConfig.max,
+    timeWindow: authenticationConfig.timeframe * 1000,
+    cache: rateLimitCacheSize,
+  });
+  const recoveryRateLimit = app.rateLimit({
+    max: recoveryConfig.max,
+    timeWindow: recoveryConfig.timeframe * 1000,
+    cache: rateLimitCacheSize,
+  });
+
   app.decorateRequest('session', undefined);
 
   app.addHook('onRequest', async (req, rep) => {
@@ -102,18 +128,22 @@ function sessionRequiredPlugin(app: FastifyInstance, opts: FastifyPluginOptions,
     },
   });
 
-  app.post('/signin', signinHandler);
+  app.post('/signin', { preHandler: authenticationRateLimit }, signinHandler);
 
   app.register(signupPlugin, { prefix: '/signup' });
 
-  app.post('/lost-password', lostPasswordHandler);
+  app.post('/lost-password', { preHandler: recoveryRateLimit }, lostPasswordHandler);
 
   app.register(signoutPlugin, { prefix: '/signout' });
 
   app.register(userPlugin, { prefix: '/users' });
   app.register(appsPlugin, { prefix: '/apps' });
 
-  app.register(meilingV1SessionAuthnPlugin, { prefix: '/authn' });
+  app.register(meilingV1SessionAuthnPlugin, {
+    prefix: '/authn',
+    authenticationRateLimit,
+    recoveryRateLimit,
+  });
 
   done();
 }

--- a/src/routes/v1/meiling/session.ts
+++ b/src/routes/v1/meiling/session.ts
@@ -1,11 +1,21 @@
 import { FastifyInstance, FastifyPluginOptions } from 'fastify';
 import { Meiling } from '../../../common';
+import { rateLimitCacheSize } from '../../../common/fastify';
 import { BaridegiLogType, sendBaridegiLog } from '../../../common/event/baridegi';
+import config from '../../../resources/config';
 
 export function sessionPlugin(app: FastifyInstance, opts: FastifyPluginOptions, done: () => void): void {
+  const sessionRateLimit = app.rateLimit({
+    max: config.session.v1.rateLimit.maxTokenPerIP,
+    timeWindow: config.session.v1.rateLimit.timeframe * 1000,
+    cache: rateLimitCacheSize,
+    allowList: (req) => Meiling.Authentication.Token.getTokenFromRequest(req) !== undefined,
+  });
+
   app.get(
     '/',
     {
+      preHandler: sessionRateLimit,
       schema: {
         description: 'Issue a new Session token or Verify Session token for meiliNG V1 Endpoints',
         tags: ['meiling'],
@@ -30,6 +40,10 @@ export function sessionPlugin(app: FastifyInstance, opts: FastifyPluginOptions, 
           },
           400: {
             description: 'Provided Token is invalid',
+            $ref: 'MeilingV1Error#',
+          },
+          429: {
+            description: 'Rate limit exceeded',
             $ref: 'MeilingV1Error#',
           },
           500: {
@@ -61,17 +75,10 @@ export function sessionPlugin(app: FastifyInstance, opts: FastifyPluginOptions, 
           token: token,
         });
 
-        if (token) {
-          return rep.status(201).send({
-            success: true,
-            token,
-          });
-        } else {
-          throw new Meiling.V1.Error.MeilingError(
-            Meiling.V1.Error.ErrorType.INTERNAL_SERVER_ERROR,
-            'Failed to issue a token',
-          );
-        }
+        return rep.status(201).send({
+          success: true,
+          token,
+        });
       }
     },
   );

--- a/src/routes/v1/meiling/signup/index.ts
+++ b/src/routes/v1/meiling/signup/index.ts
@@ -3,8 +3,16 @@ import { Meiling } from '../../../../common';
 import { Utils } from '../../../../common/';
 import config from '../../../../resources/config';
 import { signupHandler } from './signup';
+import { rateLimitCacheSize, rateLimitDefaults } from '../../../../common/fastify';
 
 export function signupPlugin(app: FastifyInstance, opts: FastifyPluginOptions, done: () => void): void {
+  const signupConfig = config.meiling.rateLimit?.signup ?? rateLimitDefaults.signup;
+  const signupRateLimit = app.rateLimit({
+    max: signupConfig.max,
+    timeWindow: signupConfig.timeframe * 1000,
+    cache: rateLimitCacheSize,
+  });
+
   app.addHook('onRequest', (req, rep, next) => {
     if (!config.meiling.signup.enabled) {
       throw new Meiling.V1.Error.MeilingError(Meiling.V1.Error.ErrorType.NOT_IMPLEMENTED, 'Signup is disabled');
@@ -17,6 +25,7 @@ export function signupPlugin(app: FastifyInstance, opts: FastifyPluginOptions, d
   app.post(
     '/',
     {
+      preHandler: signupRateLimit,
       schema: {
         description: 'Endpoint to sign-up an account',
         tags: ['meiling'],
@@ -50,6 +59,10 @@ export function signupPlugin(app: FastifyInstance, opts: FastifyPluginOptions, d
             properties: {
               success: { type: 'boolean' },
             },
+          },
+          429: {
+            description: 'Rate limit exceeded',
+            $ref: 'MeilingV1Error#',
           },
         },
       },


### PR DESCRIPTION
This pull request introduces a robust and configurable rate limiting system for security-sensitive endpoints in the Meiling authentication API. It adds per-endpoint rate limit controls, updates dependencies to support the new features, and removes legacy, ad-hoc rate limiting code. The changes ensure that authentication, recovery, signup, and session token issuance endpoints are protected from abuse, with clear configuration options and improved maintainability.

**Key changes:**

**1. Rate limiting implementation and configuration**
- Added a new `rateLimit` configuration section under `meiling` in `config.env.js`, `config.example.js`, and the `ConfigInterface` TypeScript interface, allowing for fine-grained control over authentication, recovery, and signup endpoint rate limits. [[1]](diffhunk://#diff-9c67cfbd950360c48ac1c61452119fa5e00cbc343ac18458b712ecd6b2cfafbbR72-R85) [[2]](diffhunk://#diff-aac8a3d4c7f0c0698ca6bcbb887550053eb06a3faac1cb22b904b1dfc92b9cf3R75-R89) [[3]](diffhunk://#diff-2b689669be6a1346d9e6c363574988ba4ffa962c0ec2fdd6d262fbd2a864123bR77-R81) [[4]](diffhunk://#diff-2b689669be6a1346d9e6c363574988ba4ffa962c0ec2fdd6d262fbd2a864123bR140-R144)
- Introduced a new utility module `src/common/fastify/rate-limit.ts` that provides helpers for IP normalization, default rate limit values, and cache size, ensuring consistent and secure rate limiting across endpoints.

**2. Dependency and lockfile updates**
- Added `@fastify/rate-limit@9.1.0` and updated `ipaddr.js` to `2.4.0` in `package.json` and `pnpm-lock.yaml` to support the new rate limiting features and IP normalization. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R12) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R27) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR17-R19) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR62-R64) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR397-R399) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR423-R426) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1318-R1332) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2011-R2014) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2279-R2284) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2311-R2312) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2316-R2341) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3281-R3306) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3996-R3997)

**3. Endpoint integration**
- Registered and configured the Fastify rate limit plugin in the Meiling API, applying per-endpoint rate limiting to `/signin`, `/lost-password`, `/authn/issue`, `/authn/verify`, and session endpoints, using IP normalization and custom error responses. [[1]](diffhunk://#diff-e5a392f475668d26597be3b355c86c7395f06b50abe9b94ba08a19d049db6af7R1) [[2]](diffhunk://#diff-e5a392f475668d26597be3b355c86c7395f06b50abe9b94ba08a19d049db6af7R17) [[3]](diffhunk://#diff-e5a392f475668d26597be3b355c86c7395f06b50abe9b94ba08a19d049db6af7R28-R38) [[4]](diffhunk://#diff-e5a392f475668d26597be3b355c86c7395f06b50abe9b94ba08a19d049db6af7R96-R108) [[5]](diffhunk://#diff-e5a392f475668d26597be3b355c86c7395f06b50abe9b94ba08a19d049db6af7L105-R146) [[6]](diffhunk://#diff-a6b6c38004b62fe7f56b2216ea8f8a9a761572b798815e63c411523f486bbf77L1-R16) [[7]](diffhunk://#diff-022b56bc1274e2afb13d4a59f6ee59a58abdbef5c98da74cc14cff8a5ed8c053R3-R18) [[8]](diffhunk://#diff-022b56bc1274e2afb13d4a59f6ee59a58abdbef5c98da74cc14cff8a5ed8c053R45-R48)

**4. Removal of legacy rate limiting logic**
- Removed old, manual rate limiting code from the session token creation logic in `src/common/meiling/v1/session.ts`, fully replacing it with the new, centralized Fastify-based approach. [[1]](diffhunk://#diff-4c3238ef67043f8e4c5c7d1cd0f83c2d96ce6a1861a06b559d1415d8b920f194L33-L34) [[2]](diffhunk://#diff-4c3238ef67043f8e4c5c7d1cd0f83c2d96ce6a1861a06b559d1415d8b920f194L142-L164) [[3]](diffhunk://#diff-4c3238ef67043f8e4c5c7d1cd0f83c2d96ce6a1861a06b559d1415d8b920f194L176-L188) [[4]](diffhunk://#diff-4c3238ef67043f8e4c5c7d1cd0f83c2d96ce6a1861a06b559d1415d8b920f194L202)

**5. Type and interface improvements**
- Updated TypeScript types and interfaces to reflect the new configuration structure for rate limits, improving type safety and documentation. [[1]](diffhunk://#diff-2b689669be6a1346d9e6c363574988ba4ffa962c0ec2fdd6d262fbd2a864123bR77-R81) [[2]](diffhunk://#diff-2b689669be6a1346d9e6c363574988ba4ffa962c0ec2fdd6d262fbd2a864123bR140-R144)

These changes make rate limiting more consistent, configurable, and maintainable across the authentication API.